### PR TITLE
Issue 1: Fix Wh_Σ and state class

### DIFF
--- a/custom_components/openems/helpers.py
+++ b/custom_components/openems/helpers.py
@@ -32,7 +32,7 @@ def device_to_state_class(device_class: SensorDeviceClass) -> SensorStateClass |
     """Derive SensorStateClass from SensorDeviceClass."""
     match device_class:
         case SensorDeviceClass.ENERGY:
-            return None
+            return SensorStateClass.TOTAL_INCREASING
         case SensorDeviceClass.ENUM:
             return None
         case _:

--- a/custom_components/openems/sensor.py
+++ b/custom_components/openems/sensor.py
@@ -88,6 +88,9 @@ async def async_setup_entry(
                     enum_dict = {v: k for k, v in channel["options"].items()}
                     del channel["options"]
                 else:
+                    # convert openems sum unit to something HA can deal with
+                    if channel["unit"] == "Wh_Σ":
+                        channel["unit"] = "Wh"
                     device_class = unit_to_deviceclass(channel["unit"])
                     enum_dict = {}
                 entity_description = OpenEMSEntityDescription(


### PR DESCRIPTION
This will fix all energy meters of OpenEMS to use a unit that works with Home Assistant and its energy dashboard specifically. Since the new unit is `Wh` it also requires the pricing to be in `Currency/Wh` instead of the - maybe - expected `Currency/kWh`. Something users need to be aware of but it is mentioned when adding the sensor to the energy dashboard.